### PR TITLE
Add GitHub Action to Run MSBuild

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -3,7 +3,7 @@ name: Build version.dll
 on:
   workflow_dispatch:
   push:
-    branches: [ "master" ]
+    branches: [ "*" ]
   pull_request:
     branches: [ "master" ]
 

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -1,6 +1,7 @@
 name: Build version.dll
 
 on:
+  workflow_dispatch:
   push:
     branches: [ "master" ]
   pull_request:

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -1,0 +1,39 @@
+name: Build version.dll
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+env:
+  SOLUTION_FILE_PATH: .
+  BUILD_CONFIGURATION: Release
+  VCPKG_ROOT: ${{ github.workspace }}\vcpkg
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Add MSBuild to PATH
+      uses: microsoft/setup-msbuild@v1.0.2
+
+    - name: Clone vcpkg
+      run: git clone https://github.com/microsoft/vcpkg.git
+
+    - name: Bootstrap vcpkg
+      run: .\vcpkg\bootstrap-vcpkg.bat
+      shell: cmd
+
+    - name: Install dependencies from manifest
+      run: .\vcpkg\vcpkg.exe install --triplet x64-windows-static
+      shell: cmd
+
+    - name: Build with vcpkg
+      run: msbuild /m /p:Configuration=Release ${{env.SOLUTION_FILE_PATH}}

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -36,5 +36,12 @@ jobs:
       run: .\vcpkg\vcpkg.exe install --triplet x64-windows-static
       shell: cmd
 
-    - name: Build with vcpkg
-      run: msbuild /m /p:Configuration=Release ${{env.SOLUTION_FILE_PATH}}
+    - name: Run MSBuild with vcpkg
+      run: msbuild ${{env.SOLUTION_FILE_PATH}} /m /p:Configuration=Release /p:VcpkgTriplet=x64-windows-static
+      shell: cmd
+
+    - name: Upload version.dll as artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: version-build-artifacts
+        path: x64/Release/

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,3 @@
+<Project>
+  <Import Condition="Exists('$(VCPKG_ROOT)\scripts\buildsystems\msbuild\vcpkg.targets')" Project="$(VCPKG_ROOT)\scripts\buildsystems\msbuild\vcpkg.targets" />
+</Project>


### PR DESCRIPTION
- Automatically runs a build when a new commit is pushed
- Enable manual trigger for running a build
- Builds with upload version.dll as an artifact so that you do not need to build locally.